### PR TITLE
Last change needed to revert to 9-bit RSSI register

### DIFF
--- a/driver/bk4819.c
+++ b/driver/bk4819.c
@@ -221,7 +221,7 @@ void BK4819_WriteRegister(uint8_t Reg, uint16_t Data)
 
 uint16_t BK4819_GetRSSI(void)
 {
-	RawRSSI = BK4819_ReadRegister(0x67) & 0x01FF;
+	return BK4819_ReadRegister(0x67) & 0x01FF;
 }
 
 void BK4819_Init(void)

--- a/driver/bk4819.c
+++ b/driver/bk4819.c
@@ -221,12 +221,7 @@ void BK4819_WriteRegister(uint8_t Reg, uint16_t Data)
 
 uint16_t BK4819_GetRSSI(void)
 {
-	uint16_t RawRSSI;
-	
 	RawRSSI = BK4819_ReadRegister(0x67) & 0x01FF;
-	// RawRSSI = RawRSSI >> 1;
-	return RawRSSI;
-//	return BK4819_ReadRegister(0x67) & 0x01FF;
 }
 
 void BK4819_Init(void)

--- a/task/rssi.c
+++ b/task/rssi.c
@@ -101,13 +101,13 @@ static void CheckRSSI(void)
 		
 		RXdBM = (RSSI>>1)-160;  // Using same rssi to dBM conversion as uv-k5.  Don't know if this is right.
 
-		//Valid range is 36 - 166
-		if (RSSI < 36) {
+		//Valid range is 72 - 330
+		if (RSSI < 72) {
 			Power = 0;
-		} else if (RSSI > 166) {
+		} else if (RSSI > 330) {
 			Power = 100;
 		} else {
-			Power = ((RSSI-36)*100)/130;
+			Power = ((RSSI-72)*100)/258;
 		}
 
 		// Convert to pos number to work with string funcs that require uint


### PR DESCRIPTION
Adjust the signal bar ranges to match the 9-bit values.  Prevents bar from being pinned at 100% all the time.